### PR TITLE
Add Natvis definitions for url types and create tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,8 +25,6 @@ jobs:
             rust: beta
           - os: macos-latest
             rust: nightly
-          - os: windows-latest
-            rust: nightly
 
     runs-on: ${{ matrix.os }}
 
@@ -45,6 +43,16 @@ jobs:
         with:
           command: test
           args: --all-features
+      # The #[debugger_visualizer] attribute is currently gated behind an unstable feature flag.
+      # In order to test the visualizers for the url crate, they have to be tested on a nightly build.
+      - name: Run debugger_visualizer tests
+        if: |
+          matrix.os == 'windows-latest' &&
+          matrix.rust == 'nightly'
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --test debugger_visualizer --all-features -- --test-threads=1
 
   WASM:
     runs-on: ubuntu-latest

--- a/debug_metadata/url.natvis
+++ b/debug_metadata/url.natvis
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<AutoVisualizer xmlns="http://schemas.microsoft.com/vstudio/debugger/natvis/2010">
+  <Type Name="url::Url">
+    <Intrinsic Name="ptr" Expression="serialization.vec.buf.ptr.pointer.pointer" />
+    <DisplayString>{serialization}</DisplayString>
+    <Expand>
+      <Synthetic Name="[scheme]">
+        <DisplayString>{(char*)(ptr()),[scheme_end]s8}</DisplayString>
+      </Synthetic>
+      <Synthetic Name="[username]" Condition="username_end > (scheme_end + 3)">
+        <!-- Add 3 to the scheme end to account for the scheme separator which is '://' -->
+        <DisplayString>{(char*)(ptr()+(scheme_end + 3)),[((username_end)-(scheme_end + 3))]s8}</DisplayString>
+      </Synthetic>
+      <Synthetic Name="[host]" Condition="host.discriminant != 0">
+        <DisplayString>{(char*)(ptr()+host_start),[host_end-host_start]s8}</DisplayString>
+      </Synthetic>
+      <Synthetic Name="[port]" Condition="port.discriminant == 1">
+        <DisplayString>{port.variant1.__0,d}</DisplayString>
+      </Synthetic>
+      <Synthetic Name="[path]">
+        <DisplayString Condition="query_start.discriminant == 0 &amp;&amp; fragment_start.discriminant == 0">{(char*)(ptr()+path_start),[(serialization.vec.len-path_start)]s8}</DisplayString>
+        <DisplayString Condition="query_start.discriminant == 1">{(char*)(ptr()+path_start),[(query_start.variant1.__0-path_start)]s8}</DisplayString>
+        <DisplayString Condition="fragment_start.discriminant == 1">{(char*)(ptr()+path_start),[(fragment_start.variant1.__0-path_start)]s8}</DisplayString>
+      </Synthetic>
+      <Synthetic Name="[query]" Condition="query_start.discriminant == 1">
+        <DisplayString Condition="fragment_start.discriminant == 0">{(char*)(ptr()+query_start.variant1.__0+1),[((serialization.vec.len)-(query_start.variant1.__0+1))]s8}</DisplayString>
+        <DisplayString Condition="fragment_start.discriminant == 1">{(char*)(ptr()+query_start.variant1.__0+1),[((fragment_start.variant1.__0)-(query_start.variant1.__0+1))]s8}</DisplayString>
+      </Synthetic>
+      <Synthetic Name="[fragment]" Condition="fragment_start.discriminant == 1">
+        <DisplayString>{(char*)(ptr()+fragment_start.variant1.__0+1),[(serialization.vec.len-fragment_start.variant1.__0-1)]s8}</DisplayString>
+      </Synthetic>
+    </Expand>
+  </Type>
+</AutoVisualizer>

--- a/url/Cargo.toml
+++ b/url/Cargo.toml
@@ -20,9 +20,15 @@ rust-version = "1.45"
 travis-ci = { repository = "servo/rust-url" }
 appveyor = { repository = "Manishearth/rust-url" }
 
+[build-dependencies]
+rustc_version = "0.4"
+
 [dev-dependencies]
 serde_json = "1.0"
 bencher = "0.1"
+# To test debugger visualizers defined for the url crate such as url.natvis
+debugger_test = "0.1"
+debugger_test_parser = "0.1"
 
 [dependencies]
 form_urlencoded = { version = "1.0.0", path = "../form_urlencoded" }
@@ -32,8 +38,14 @@ serde = {version = "1.0", optional = true, features = ["derive"]}
 
 [features]
 default = ["idna"]
+# Enable to use the #[debugger_visualizer] attribute.
 
 [[bench]]
 name = "parse_url"
 path = "benches/parse_url.rs"
 harness = false
+
+[[test]]
+name = "debugger_visualizer"
+path = "tests/debugger_visualizer.rs"
+test = false

--- a/url/build.rs
+++ b/url/build.rs
@@ -1,0 +1,8 @@
+use rustc_version::{version_meta, Channel};
+
+fn main() {
+    // Set the `debugger_visualizer` cfg flag if the nightly channel is being used.
+    if Channel::Nightly == version_meta().unwrap().channel {
+        println!("cargo:rustc-cfg=debugger_visualizer");
+    }
+}

--- a/url/src/lib.rs
+++ b/url/src/lib.rs
@@ -131,6 +131,11 @@ url = { version = "2", default-features = false }
 */
 
 #![doc(html_root_url = "https://docs.rs/url/2.2.2")]
+#![cfg_attr(
+    debugger_visualizer,
+    feature(debugger_visualizer),
+    debugger_visualizer(natvis_file = "../../debug_metadata/url.natvis")
+)]
 
 pub use form_urlencoded;
 

--- a/url/tests/common/mod.rs
+++ b/url/tests/common/mod.rs
@@ -1,0 +1,30 @@
+use serde_json::Value;
+
+pub trait JsonExt {
+    fn take_key(&mut self, key: &str) -> Option<Value>;
+    fn string(self) -> String;
+    fn maybe_string(self) -> Option<String>;
+    fn take_string(&mut self, key: &str) -> String;
+}
+
+impl JsonExt for Value {
+    fn take_key(&mut self, key: &str) -> Option<Value> {
+        self.as_object_mut().unwrap().remove(key)
+    }
+
+    fn string(self) -> String {
+        self.maybe_string().expect("")
+    }
+
+    fn maybe_string(self) -> Option<String> {
+        match self {
+            Value::String(s) => Some(s),
+            Value::Null => None,
+            _ => panic!("Not a Value::String or Value::Null"),
+        }
+    }
+
+    fn take_string(&mut self, key: &str) -> String {
+        self.take_key(key).unwrap().string()
+    }
+}

--- a/url/tests/data.rs
+++ b/url/tests/data.rs
@@ -13,6 +13,9 @@ use std::str::FromStr;
 use serde_json::Value;
 use url::{quirks, Url};
 
+mod common;
+use common::JsonExt;
+
 #[test]
 fn urltestdata() {
     #[cfg(not(feature = "idna"))]
@@ -183,35 +186,6 @@ fn check_invariants(url: &Url, name: &str, comment: Option<&str>) -> bool {
     }
 
     passed
-}
-
-trait JsonExt {
-    fn take_key(&mut self, key: &str) -> Option<Value>;
-    fn string(self) -> String;
-    fn maybe_string(self) -> Option<String>;
-    fn take_string(&mut self, key: &str) -> String;
-}
-
-impl JsonExt for Value {
-    fn take_key(&mut self, key: &str) -> Option<Value> {
-        self.as_object_mut().unwrap().remove(key)
-    }
-
-    fn string(self) -> String {
-        self.maybe_string().expect("")
-    }
-
-    fn maybe_string(self) -> Option<String> {
-        match self {
-            Value::String(s) => Some(s),
-            Value::Null => None,
-            _ => panic!("Not a Value::String or Value::Null"),
-        }
-    }
-
-    fn take_string(&mut self, key: &str) -> String {
-        self.take_key(key).unwrap().string()
-    }
 }
 
 fn get<'a>(url: &'a Url, attr: &str) -> &'a str {

--- a/url/tests/debugger_visualizer.rs
+++ b/url/tests/debugger_visualizer.rs
@@ -1,0 +1,71 @@
+#![cfg(debugger_visualizer)]
+
+mod common;
+use common::JsonExt;
+
+use std::str::FromStr;
+
+use debugger_test::debugger_test;
+use serde_json::Value;
+use url::Url;
+
+#[inline(never)]
+fn __break() {}
+
+#[debugger_test(
+    debugger = "cdb",
+    commands = "
+    .nvlist
+
+    dx _urls
+
+    dx _urls[0]
+
+    dx _urls[1]
+
+    dx _urls[2]
+
+    dx _urls[3]
+
+    dx _urls[4]",
+    expected_statements = r#"
+    pattern:debugger_visualizer-.*\.exe \(embedded NatVis ".*debugger_visualizer-0\.natvis"\)"#
+)]
+fn test_url_visualizer() {
+    // Copied from https://github.com/web-platform-tests/wpt/blob/master/url/
+    let mut json = Value::from_str(include_str!("urltestdata.json"))
+        .expect("JSON parse error in urltestdata.json");
+
+    let _urls = json
+        .as_array_mut()
+        .unwrap()
+        .iter_mut()
+        .filter_map(|entry| {
+            if entry.is_string() || entry.take_key("failure").is_some() {
+                return None;
+            }
+
+            let maybe_base = entry
+                .take_key("base")
+                .expect("missing base key")
+                .maybe_string();
+            let input = entry.take_string("input");
+
+            let res = if let Some(base) = maybe_base {
+                Url::parse(&base)
+                    .expect(format!("must be able to parse base: `{}` into a URL", &base).as_str())
+                    .join(&input)
+            } else {
+                Url::parse(&input)
+            };
+
+            Some(
+                res.expect(
+                    format!("must be able to parse input: `{}` into a URL", &input).as_str(),
+                ),
+            )
+        })
+        .collect::<Vec<Url>>();
+
+    __break();
+}


### PR DESCRIPTION
Add Natvis definitions for url types and create tests to ensure visualizations do not become stale or broken.

Add a new build script that enables the `debugger_visualizer` feature for the url crate if the nightly toolchain is being used.